### PR TITLE
Static effect descriptions, instance uniforms

### DIFF
--- a/js/effects/converge.js
+++ b/js/effects/converge.js
@@ -61,56 +61,61 @@ class ConvergeConfigUI extends ConfigUI {
 }
 
 export default class ConvergeEffect extends Effect {
-  static insertIntoVertexShader(vertexShader, instance) {
-    // eslint-disable-next-line no-param-reassign, prefer-template
-    vertexShader.uniforms += `
-      uniform float convergeTime;
-      uniform float convergeSpeed;
-      uniform float convergeRotationSpeed;
-      uniform float convergeMaxTravelTime;
-    `;
-    // eslint-disable-next-line no-param-reassign, prefer-template
-    vertexShader.mainBody += `
-      {
-        vec2 screenTarget = ` + {
-          center:        'vec2(0., 0.)',
-          'color wheel': 'getDirectionVector(hsv[0] + convergeTime * convergeRotationSpeed) * vec2(.8) * vec2(invScreenAspectRatio, 1.)'
-        }[instance.config.target] + `;
+  static getUniforms() {
+    return [{
+        name: 'convergeTime',
+        type: 'float',
+        getValue: (instance) => function(ctx) {
+          const period = 2 * Math.sqrt(2 / instance.config.speed);
+
+          return fract(ctx.time / period) * period;
+        }
+      }, {
+        name: 'convergeSpeed',
+        type: 'float',
+        getValue: (instance) => instance.config.speed
+      }, {
+        name: 'convergeRotationSpeed',
+        type: 'float',
+        getValue: (instance) => instance.config.rotationSpeed
+      }, {
+        name: 'convergeMaxTravelTime',
+        type: 'float',
+        getValue: (instance) => Math.sqrt(2 / instance.config.speed)
+      }
+    ];
+  }
+
+  static getCode() {
+    const u = Effect.createUniformToken;
+
+    return [`{
+        vec2 screenTarget = `, (instance) => {
+          return {
+            center:        'vec2(0., 0.)',
+            'color wheel': [ 'getDirectionVector(hsv[0] + ', u('convergeTime'), ' * ', u('convergeRotationSpeed'), ') * vec2(.8) * vec2(invScreenAspectRatio, 1.)' ]
+          }[instance.config.target];
+        }, `;
         vec2 target = (invViewProjectionMatrix * vec4(screenTarget, 0, 1)).xy;
 
         vec2 d = target - initialPosition.xy;
         float d_len = length(d);
-        
-        float stop_t = sqrt(2. * d_len / convergeSpeed);
 
-        if(convergeTime < stop_t) {
-          float t = min(convergeTime, stop_t);
-          position.xy += .5 * d / d_len * convergeSpeed * t * t;
-        } else if(convergeTime < convergeMaxTravelTime) {
+        float stop_t = sqrt(2. * d_len / `, u('convergeSpeed'), `);
+
+        if(`, u('convergeTime'), ` < stop_t) {
+          float t = min(`, u('convergeTime'), `, stop_t);
+          position.xy += .5 * d / d_len * `, u('convergeSpeed'), ` * t * t;
+        } else if(`, u('convergeTime'), ` < `, u('convergeMaxTravelTime'), `) {
           position.xy += d;
         } else {
-          float t = convergeTime - convergeMaxTravelTime;
+          float t = `, u('convergeTime'), ` - `, u('convergeMaxTravelTime'), `;
           //position.xy += mix(d, vec2(0.), 1. - (1.-t) * (1.-t));
           //position.xy += mix(d, vec2(0.), t * t);
-          position.xy += mix(d, vec2(0.), -cos(t / convergeMaxTravelTime * PI) * .5 + .5);
+          position.xy += mix(d, vec2(0.), -cos(t / `, u('convergeMaxTravelTime'), ` * PI) * .5 + .5);
         }
-      }
-    `;
-  }
-
-  static insertUniforms(uniforms, instance) {
-    // eslint-disable-next-line no-param-reassign
-    uniforms.convergeTime = (ctx) => {
-      const period = 2 * Math.sqrt(2 / instance.config.speed);
-
-      return fract(ctx.time / period) * period;
-    };
-    // eslint-disable-next-line no-param-reassign
-    uniforms.convergeSpeed = () => instance.config.speed;
-    // eslint-disable-next-line no-param-reassign
-    uniforms.convergeRotationSpeed = () => instance.config.rotationSpeed;
-    // eslint-disable-next-line no-param-reassign
-    uniforms.convergeMaxTravelTime = () => Math.sqrt(2 / instance.config.speed);
+      }`
+    ];
   }
 
   static getDisplayName() {

--- a/js/effects/effect.js
+++ b/js/effects/effect.js
@@ -2,10 +2,26 @@
  * Interface for effects
  */
 export default class Effect {
-  static insertUniforms(/* uniforms */) {
+  static getUniforms() {
     throw new Error('Method not implemented');
   }
-  static insertIntoVertexShader(/* vertexShader, instance */) {
+
+  // for code generation
+  static createUniformToken(name) {
+    /* TODO: use this
+    class Uniform {
+      constructor(name) {
+        this.name = name;
+      }
+    }
+
+    return new Uniform(name);
+    */
+
+    return { what: 'uniform', name };
+  }
+
+  static getCode() {
     throw new Error('Method not implemented');
   }
 


### PR DESCRIPTION
This implements instance uniforms. As that would have meant more bloat in the Effect class (responsibility to build unique uniform names, handling the instance id), I restructured the Effect class to be descriptive only. This reduces redundant information and makes implementing and modifying effects easier, at the cost of some code quality. E.g. you might consider "const u = Effect.createUniformToken;" or the effect code being returned as a possibly nested array dirty hacks, but those let you focus on building effects instead of thinking how to manage code size and control flow for complex effects.

Please check out effect.js createUniformToken and command-builder.js assembleVertexShader handleElement whether there are better solutions.