### PR TITLE
[WIP] i18n

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,15 @@
         <div class="menu-content-inner">
           <h1>Particles</h1>
           <fieldset id="menu-general-controls">
-            <legend>General</legend>
+            <legend data-hfg-i18n-id="menu.general_settings.heading">General</legend>
+            <label id="menu-locale-control">
+              <span data-hfg-i18n-id="menu.locale_switch.desc">Language:</span>
+              <select>
+                <!-- to be filled by LocalePicker -->
+              </select>
+            </label><br/>
             <label id="menu-bg-color-control">
-              Background color:
+              <span data-hfg-i18n-id="menu.bg_color_control.desc">Background color:</span>
               <input type="color" value="#000000" />
             </label><br/>
             <fieldset>

--- a/index.html
+++ b/index.html
@@ -33,8 +33,8 @@
         name="toggle-menu-visible"
         id="toggle-menu-visible"
         class="toggle-menu-visible"
-        title="Toggle menu">
-      <label for="toggle-menu-visible" title="Toggle menu"></label>
+        data-hfg-i18n-attrs="title:menu.toggle_btn.title">
+      <label for="toggle-menu-visible" data-hfg-i18n-attrs="title:menu.toggle_btn.title"></label>
       <div class="menu-content">
         <div class="menu-content-inner">
           <h1 data-hfg-i18n-id="page.title">Particles Playground</h1>
@@ -126,6 +126,7 @@
         <button type="button"
           id="menu-btn-apply"
           class="menu-btn-apply"
+          data-hfg-i18n-id="menu.apply_btn.label"
           disabled
         >Apply</button>
       </div>
@@ -166,9 +167,9 @@
       name="btn-file-select"
       id="btn-file-select"
       class="btn-file-select"
-      title="Select image"
+      data-hfg-i18n-attrs="title:page.upload_btn.title"
       accept="image/*">
-    <label for="btn-file-select" title="Select image"></label>
+    <label for="btn-file-select" data-hfg-i18n-attrs="title:page.upload_btn.title"></label>
 
     <div id="modal-container"></div>
 

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
       <label for="toggle-menu-visible" title="Toggle menu"></label>
       <div class="menu-content">
         <div class="menu-content-inner">
-          <h1>Particles</h1>
+          <h1 data-hfg-i18n-id="page.title">Particles Playground</h1>
           <fieldset id="menu-general-controls">
             <legend data-hfg-i18n-id="menu.general_settings.heading">General</legend>
             <label id="menu-locale-control">
@@ -51,40 +51,40 @@
               <input type="color" value="#000000" />
             </label><br/>
             <fieldset>
-              <legend>Number of particles</legend>
+              <legend data-hfg-i18n-id="menu.particles.count.desc">Number of particles</legend>
               <label>
-                Horizontal (x):
+                <span data-hfg-i18n-id="menu.particles.count.horizontal">Horizontal (x):</span>
                 <input type="number" min="1" step="1" id="menu-particles-x"/>
               </label><br/>
               <label>
-                Vertical (y):
+                <span data-hfg-i18n-id="menu.particles.count.vertical">Vertical (y):</span>
                 <input type="number" min="1" step="1" id="menu-particles-y"/>
               </label>
             </fieldset>
             <label id="menu-particle-size-control">
-              Particle size:
+              <span data-hfg-i18n-id="menu.particles.size.desc">Particle size:</span>
               <input type="number" value="100" />%
             </label><br/>
             <label id="menu-particle-shape-control">
-              Particle shape:
+              <span data-hfg-i18n-id="menu.particles.shape.desc">Particle shape:</span>
               <select>
-                <option value="circle" selected>circle</option>
-                <option value="square">square</option>
-                <option value="triangle">triangle</option>
+                <option value="circle" data-hfg-i18n-id="menu.particles.shape.circle" selected>circle</option>
+                <option value="square" data-hfg-i18n-id="menu.particles.shape.square">square</option>
+                <option value="triangle" data-hfg-i18n-id="menu.particles.shape.triangle">triangle</option>
               </select>
             </label><br/>
             <label id="menu-particle-edge-fade-control">
-              Particle edge fading:
+              <span data-hfg-i18n-id="menu.particles.fading.desc">Particle edge fading:</span>
               <select>
-                <option value="none" selected>none</option>
-                <option value="fade-out">fade out</option>
+                <option value="none" data-hfg-i18n-id="menu.particles.fading.none" selected>none</option>
+                <option value="fade-out" data-hfg-i18n-id="menu.particles.fading.fade_out">fade out</option>
               </select>
             </label><br/>
             <label id="menu-particle-overlap-control">
-              Particle overlap:
+              <span data-hfg-i18n-id="menu.particles.overlap.desc">Particle overlap:</span>
               <select>
-                <option value="add">glow</option>
-                <option value="alpha blend" selected>blend</option>
+                <option value="add" data-hfg-i18n-id="menu.particles.overlap.glow">glow</option>
+                <option value="alpha blend" data-hfg-i18n-id="menu.particles.overlap.blend" selected>blend</option>
               </select>
             </label>
           </fieldset>
@@ -94,31 +94,31 @@
           -->
           <div class="menu-state-ctrl-buttons">
             <label id="menu-btn-importstate" class="menu-btn-importstate">
-              Load
+              <span data-hfg-i18n-id="menu.state.load">Load</span>
               <input type="file" accept=".json,application/json"/>
             </label>
-            <button type="button" id="menu-btn-exportstate" class="menu-btn-exportstate">Save</button>
-            <button type="button" id="menu-btn-resetstate" class="menu-btn-resetstate">Reset</button>
+            <button type="button" id="menu-btn-exportstate" class="menu-btn-exportstate" data-hfg-i18n-id="menu.state.save">Save</button>
+            <button type="button" id="menu-btn-resetstate" class="menu-btn-resetstate" data-hfg-i18n-id="menu.state.reset">Reset</button>
           </div>
           <label class="menu-select-preset-control">
             <select>
-              <option value="" disabled selected>Load a preset configuration</option>
+              <option value="" disabled selected data-hfg-i18n-id="menu.state.load_preset.prompt">Load a preset configuration</option>
             </select>
           </label><br />
           <ul class="menu-effect-list">
             <!-- Effects will be listed here -->
           </ul>
           <div class="menu-weblinks-container">
-            Weblinks:
+            <span data-hfg-i18n-id="menu.weblinks.desc">Weblinks:</span>
             <ul>
               <li><a href="https://github.com/suluke/hfg-particles/tree/master/manual/MANUAL.md">
-                <span class="fa fa-book" /> Manual
+                <span class="fa fa-book" /> <span data-hfg-i18n-id="menu.weblinks.manual">Manual</span>
               </a></li>
               <li><a href="https://github.com/suluke/hfg-particles">
-                <span class="fa fa-github" /> Source Code (Github, MIT License)
+                <span class="fa fa-github" /> <span data-hfg-i18n-id="menu.weblinks.source_code">Source Code (Github, MIT License)</span>
               </a></li>
               <li><a href="https://commons.wikimedia.org/wiki/File:Edgar_Germain_Hilaire_Degas_071.jpg">
-                <span class="fa fa-image" /> Default image by Edgar Degas (Wikimedia Commons)
+                <span class="fa fa-image" /> <span data-hfg-i18n-id="menu.weblinks.default_image">Default image by Edgar Degas (Wikimedia Commons)</span>
               </a></li>
             </ul>
           </div>
@@ -160,7 +160,7 @@
 
     <p class="file-drag-indicator">
       <span class="file-drag-icon"></span>
-      Drop image file to load
+      <span data-hfg-i18n-id="page.dropzone.desc">Drop image file to load</span>
     </p>
     <input type="file"
       name="btn-file-select"

--- a/js/effects/change-image.js
+++ b/js/effects/change-image.js
@@ -3,7 +3,6 @@ import { parseHtml, imageScalingMarkup } from '../ui/util';
 import { NonFatalError } from '../error-manager';
 
 const EffectName = 'Change Image';
-const EffectDescription = 'Changes the particle data to a configurable image (file or url)';
 
 const States = {
   INVALID: 0,
@@ -172,12 +171,8 @@ export default class ChangeImageEffect extends Effect {
     });
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'change_image';
   }
 
   static getConfigUI() {

--- a/js/effects/converge-circle.js
+++ b/js/effects/converge-circle.js
@@ -2,7 +2,6 @@ import Effect, { ConfigUI, fract } from './effect';
 import { parseHtml } from '../ui/util';
 
 const EffectName = 'Converge to circle';
-const EffectDescription = 'Particles are attracted towards their position on an HSV color wheel centered around the center of the screen';
 
 class ConvergeCircleConfigUI extends ConfigUI {
   constructor() {
@@ -77,12 +76,8 @@ export default class ConvergeCircleEffect extends Effect {
     `;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'converge_circle';
   }
 
   static getConfigUI() {

--- a/js/effects/converge-point.js
+++ b/js/effects/converge-point.js
@@ -2,7 +2,6 @@ import Effect, { ConfigUI, fract } from './effect';
 import { parseHtml } from '../ui/util';
 
 const EffectName = 'Converge to point';
-const EffectDescription = 'Particles are attracted towards the center of the screen';
 
 class ConvergePointConfigUI extends ConfigUI {
   constructor() {
@@ -64,12 +63,8 @@ export default class ConvergePointEffect extends Effect {
     `;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'converge_point';
   }
 
   static getConfigUI() {

--- a/js/effects/dummy.js
+++ b/js/effects/dummy.js
@@ -2,7 +2,6 @@ import Effect, { ConfigUI, fract } from './effect';
 import { parseHtml } from '../ui/util';
 
 const EffectName = 'Dummy';
-const EffectDescription = 'An effect that has no effect - useful to extend the timeline length without having anything happen';
 
 class DummyConfigUI extends ConfigUI {
   constructor() {
@@ -33,12 +32,8 @@ export default class DummyEffect extends Effect {
   static register(instance, props, uniforms, vertexShader) {
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'dummy';
   }
 
   static getConfigUI() {

--- a/js/effects/effect.js
+++ b/js/effects/effect.js
@@ -16,7 +16,7 @@ export default class Effect {
     return this.name;
   }
 
-  static getDisplayName() {
+  static getTranslationId() {
     throw new Error('Method not implemented');
   }
 
@@ -29,10 +29,6 @@ export default class Effect {
   }
 
   static getRandomConfig() {
-    throw new Error('Method not implemented');
-  }
-
-  static getDescription() {
     throw new Error('Method not implemented');
   }
 

--- a/js/effects/flickr-image.js
+++ b/js/effects/flickr-image.js
@@ -3,7 +3,6 @@ import { parseHtml, imageScalingMarkup } from '../ui/util';
 import Flickr, { ApiKey } from '../polyfills/flickr';
 
 const EffectName = 'Flickr Image';
-const EffectDescription = 'Changes the underlying image to one loaded from Flickr\'s recent images feed';
 const Attribution = 'This product uses the Flickr API but is not endorsed or certified by Flickr.';
 
 class FlickrImageConfigUI extends ConfigUI {
@@ -309,12 +308,8 @@ export default class FlickrImageEffect extends Effect {
     });
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'flickr_image';
   }
 
   static getConfigUI() {

--- a/js/effects/hue-displace.js
+++ b/js/effects/hue-displace.js
@@ -2,7 +2,6 @@ import Effect, { ConfigUI, fract } from './effect';
 import { parseHtml } from '../ui/util';
 
 const EffectName = 'Displace by hue';
-const EffectDescription = 'Particles move into different directions depending on their hue';
 
 class HueDisplaceConfigUI extends ConfigUI {
   constructor() {
@@ -99,12 +98,8 @@ export default class HueDisplaceEffect extends Effect {
     }
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'hue_displace';
   }
 
   static getConfigUI() {

--- a/js/effects/particle-displace.js
+++ b/js/effects/particle-displace.js
@@ -3,7 +3,6 @@ import { parseHtml } from '../ui/util';
 import Ease from './ease-mixins';
 
 const EffectName = 'Displace Particles';
-const EffectDescription = 'Displaces all particles into a certain direction by the same distance';
 
 class ParticleDisplaceConfigUI extends ConfigUI {
   constructor() {
@@ -84,12 +83,8 @@ export default class ParticleDisplaceEffect extends Effect {
     `;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'particle_displace';
   }
 
   static getConfigUI() {

--- a/js/effects/particle-size-by-hue.js
+++ b/js/effects/particle-size-by-hue.js
@@ -3,7 +3,6 @@ import { parseHtml } from '../ui/util';
 import Ease from './ease-mixins';
 
 const EffectName = 'Particle size by hue';
-const EffectDescription = 'Particles will have different sizes depending on their color';
 
 class ParticleSizeByHueConfigUI extends ConfigUI {
   constructor() {
@@ -87,12 +86,8 @@ export default class ParticleSizeByHueEffect extends Effect {
     `;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'particle_size_by_hue';
   }
 
   static getConfigUI() {

--- a/js/effects/particle-spacing.js
+++ b/js/effects/particle-spacing.js
@@ -3,7 +3,6 @@ import { parseHtml } from '../ui/util';
 import Easing from './ease-mixins';
 
 const EffectName = 'Particle spacing';
-const EffectDescription = 'Adds or removes space between particles';
 
 class ParticleSpacingConfigUI extends ConfigUI {
   constructor() {
@@ -87,12 +86,8 @@ export default class ParticleSpacingEffect extends Effect {
     `;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'particle_spacing';
   }
 
   static getConfigUI() {

--- a/js/effects/particles-reduce.js
+++ b/js/effects/particles-reduce.js
@@ -3,7 +3,6 @@ import { parseHtml } from '../ui/util';
 import Ease from './ease-mixins';
 
 const EffectName = 'Reduce Particle Count';
-const EffectDescription = 'Drops the given amount of particles';
 
 class ParticlesReduceConfigUI extends ConfigUI {
   constructor() {
@@ -116,12 +115,8 @@ export default class ParticlesReduceEffect extends Effect {
     } 
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'particles_reduce';
   }
 
   static getConfigUI() {

--- a/js/effects/reset-default-image.js
+++ b/js/effects/reset-default-image.js
@@ -2,9 +2,6 @@ import Effect, { ConfigUI, fract } from './effect';
 import { parseHtml } from '../ui/util';
 
 const EffectName = 'Reset Default Image';
-const EffectDescription = 'This effect changes the currently active image ' +
-                          'back to the default image (i.e. what came from ' +
-                          'the server or was uploaded by the user)';
 
 class ResetDefaultImageConfigUI extends ConfigUI {
   constructor() {
@@ -50,12 +47,8 @@ export default class ResetDefaultImageEffect extends Effect {
     });
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'reset_default_image';
   }
 
   static getConfigUI() {

--- a/js/effects/smear.js
+++ b/js/effects/smear.js
@@ -3,7 +3,6 @@ import { parseHtml } from '../ui/util';
 import AccumulationEffect, { AccumulationAgent } from './accumulation';
 
 const EffectName = 'Smear';
-const EffectDescription = 'Smears the image in a circular way';
 
 class SmearConfigUI extends ConfigUI {
   constructor() {
@@ -72,12 +71,8 @@ export default class SmearEffect extends AccumulationEffect {
     return SmearAgent;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'smear';
   }
 
   static getConfigUI() {

--- a/js/effects/smooth-trails.js
+++ b/js/effects/smooth-trails.js
@@ -3,7 +3,6 @@ import { parseHtml } from '../ui/util';
 import AccumulationEffect, { AccumulationAgent } from './accumulation';
 
 const EffectName = 'Smooth trails';
-const EffectDescription = 'Enables an smoother fading image echo';
 
 class SmoothTrailsConfigUI extends ConfigUI {
   constructor() {
@@ -76,12 +75,8 @@ export default class SmoothTrailsEffect extends AccumulationEffect {
     return SmoothTrailsAgent;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'smooth_trails';
   }
 
   static getConfigUI() {

--- a/js/effects/sparkle.js
+++ b/js/effects/sparkle.js
@@ -2,7 +2,6 @@ import Effect, { ConfigUI, fract } from './effect';
 import { parseHtml } from '../ui/util';
 
 const EffectName = 'Sparkle';
-const EffectDescription = 'Particle size and brightness increase randomly';
 
 class SparkleConfigUI extends ConfigUI {
   constructor() {
@@ -157,12 +156,8 @@ export default class SparkleEffect extends Effect {
     `;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'sparkle';
   }
 
   static getConfigUI() {

--- a/js/effects/standing-wave.js
+++ b/js/effects/standing-wave.js
@@ -2,7 +2,6 @@ import Effect, { ConfigUI, fract } from './effect';
 import { parseHtml } from '../ui/util';
 
 const EffectName = 'Standing Wave';
-const EffectDescription = 'A standing wave oscillates';
 
 class StandingWaveConfigUI extends ConfigUI {
   constructor() {
@@ -125,12 +124,8 @@ export default class StandingWaveEffect extends Effect {
     }
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'standing_wave';
   }
 
   static getConfigUI() {

--- a/js/effects/trails.js
+++ b/js/effects/trails.js
@@ -3,7 +3,6 @@ import { parseHtml } from '../ui/util';
 import AccumulationEffect, { AccumulationAgent } from './accumulation';
 
 const EffectName = 'Trails';
-const EffectDescription = 'Enables an fading image echo';
 
 class TrailsConfigUI extends ConfigUI {
   constructor() {
@@ -67,12 +66,8 @@ export default class TrailsEffect extends AccumulationEffect {
     return TrailsAgent;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'trails';
   }
 
   static getConfigUI() {

--- a/js/effects/vignette.js
+++ b/js/effects/vignette.js
@@ -2,7 +2,6 @@ import Effect, { ConfigUI, fract } from './effect';
 import { parseHtml } from '../ui/util';
 
 const EffectName = 'Vignette';
-const EffectDescription = 'Fade out the edges to make it look like an old crt tv';
 
 class VignetteConfigUI extends ConfigUI {
   constructor() {
@@ -39,12 +38,8 @@ export default class VignetteEffect extends Effect {
     `;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'vignette';
   }
 
   static getConfigUI() {

--- a/js/effects/wave.js
+++ b/js/effects/wave.js
@@ -2,7 +2,6 @@ import Effect, { ConfigUI, fract } from './effect';
 import { parseHtml } from '../ui/util';
 
 const EffectName = 'Wave';
-const EffectDescription = 'A wave passes through the particles from left to right over the screen';
 
 class WaveConfigUI extends ConfigUI {
   constructor() {
@@ -94,12 +93,8 @@ export default class WaveEffect extends Effect {
     `;
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'wave';
   }
 
   static getConfigUI() {

--- a/js/effects/webcam.js
+++ b/js/effects/webcam.js
@@ -3,7 +3,6 @@ import { parseHtml, imageScalingMarkup } from '../ui/util';
 import { ImageCapture } from 'image-capture/lib/imagecapture';
 
 const EffectName = 'Webcam';
-const EffectDescription = 'Make use of the user\'s webcam as the particles\' color values';
 
 class WebcamConfigUI extends ConfigUI {
   constructor() {
@@ -242,12 +241,8 @@ export default class WebcamEffect extends Effect {
     return new WebcamEffectImpl(instance, props).start();
   }
 
-  static getDisplayName() {
-    return EffectName;
-  }
-
-  static getDescription() {
-    return EffectDescription;
+  static getTranslationId() {
+    return 'webcam';
   }
 
   static getConfigUI() {

--- a/js/ui/i18n.js
+++ b/js/ui/i18n.js
@@ -6,6 +6,7 @@ import en_US from './locales/en_US.json';
 const DefaultLocale = 'en_US';
 const AvailableLocales = { de_DE, en_US };
 const DomAttrName = 'data-hfg-i18n-id';
+const DomAttrsI18nAttr = 'data-hfg-i18n-attrs';
 
 function gettext(key, locale) {
   const parts = key.split('.');
@@ -92,6 +93,7 @@ export default class LocalizationManager {
   }
 
   manageStaticDOMElements() {
+    // Step 1: Collect nodes to localize text-content
     const elms = document.querySelectorAll(`[${DomAttrName}]`);
     for (let i = 0; i < elms.length; i++) {
       const elm = elms[i];
@@ -101,6 +103,27 @@ export default class LocalizationManager {
       }
       const elmsWithKey = this.managedDomElements[key];
       elmsWithKey.push(elm);
+    }
+
+    // Step 2: Collect nodes to localize attrs
+    const attrElms = document.querySelectorAll(`[${DomAttrsI18nAttr}]`);
+    for (let i = 0; i < attrElms.length; i++) {
+      const elm = attrElms[i];
+      const descriptor = elm.getAttribute(DomAttrsI18nAttr);
+      const attrKeyPairs = descriptor.split(';');
+      for (let j = 0; j < attrKeyPairs.length; j++) {
+        const attrKeyPair = attrKeyPairs[j];
+        const attrKey = attrKeyPair.split(':');
+        if (!attrKey.length === 2) {
+          throw new Error(`Malformed attribute i18n descriptor: ${descriptor}`);
+        }
+        const [ attr, key ] = attrKey;
+        if (!this.managedAttrs[attr]) {
+          this.managedAttrs[attr] = [];
+        }
+        const tasks = this.managedAttrs[attr];
+        tasks.push({ key, elm });
+      }
     }
   }
 

--- a/js/ui/i18n.js
+++ b/js/ui/i18n.js
@@ -88,7 +88,7 @@ export default class LocalizationManager {
     if (!this.managedAttrs[translationKey]) {
       this.managedAttrs[translationKey] = [];
     }
-    const tasks = this.managedAttrs[translationKey];
+    const tasks = this.managedAttrs[attr];
     tasks.push({ key: translationKey, elm });
   }
 

--- a/js/ui/i18n.js
+++ b/js/ui/i18n.js
@@ -1,0 +1,76 @@
+import de_DE from './locales/de_DE.json';
+import en_US from './locales/en_US.json';
+
+const DefaultLocale = 'en_US';
+const AvailableLocales = { de_DE, en_US };
+const DomAttrName = 'data-hfg-i18n-id';
+
+function translate(key, locale, domNode) {
+  const parts = key.split('.');
+  let text = locale;
+  while (parts.length > 0) {
+    const part = parts.shift();
+    if (!text[part]) {
+      console.warn(`Could not lookup key '${key}' on locale ${locale['_metadata_'].id}`);
+      text = null;
+      break;
+    }
+    text = text[part];
+  }
+  if (text !== null) {
+    domNode.textContent = text;
+  }
+}
+
+export default class LocalizationManager {
+  constructor() {
+    this.managedDomElements = {};
+    this.localeKey = DefaultLocale;
+  }
+
+  setLocale(localeKey) {
+    if (!AvailableLocales[localeKey]) {
+      console.warn(`Locale not available: ${localeKey}`);
+      return;
+    }
+    this.localeKey = localeKey;
+    this.render();
+  }
+  getLocale() {
+    return this.localeKey;
+  }
+
+  initialize() {
+    this.manageStaticDOMElements();
+    this.render();
+  }
+
+  render() {
+    const keys = Object.keys(this.managedDomElements);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const elms = this.managedDomElements[key];
+      for (let j = 0; j < elms.length; j++) {
+        const elm = elms[j];
+        translate(key, AvailableLocales[this.localeKey], elm);
+      }
+    }
+  }
+
+  manageStaticDOMElements() {
+    const elms = document.querySelectorAll(`[${DomAttrName}]`);
+    for (let i = 0; i < elms.length; i++) {
+      const elm = elms[i];
+      const key = elm.getAttribute(DomAttrName);
+      if (!this.managedDomElements[key]) {
+        this.managedDomElements[key] = [];
+      }
+      const elmsWithKey = this.managedDomElements[key];
+      elmsWithKey.push(elm);
+    }
+  }
+
+  static getAvailableLocales() {
+    return AvailableLocales;
+  }
+}

--- a/js/ui/i18n.js
+++ b/js/ui/i18n.js
@@ -1,3 +1,5 @@
+import Control from './control';
+
 import de_DE from './locales/de_DE.json';
 import en_US from './locales/en_US.json';
 
@@ -72,5 +74,49 @@ export default class LocalizationManager {
 
   static getAvailableLocales() {
     return AvailableLocales;
+  }
+}
+
+export class LocalePicker extends Control {
+  constructor(menu) {
+    this.menu = menu;
+    this.element = document.getElementById('menu-locale-control');
+    this.select = this.element.querySelector('select');
+
+    this.localizationManager = new LocalizationManager();
+
+    const locales = LocalizationManager.getAvailableLocales();
+    const localeKeys = Object.keys(locales);
+    const opts = document.createDocumentFragment();
+    for (let i = 0; i < localeKeys.length; i++) {
+      const key = localeKeys[i];
+      const locale = locales[key];
+      const opt = document.createElement('option');
+      opt.value = key;
+      opt.textContent = locale._metadata_.name;
+      if (this.localizationManager.getLocale() === key) {
+        opt.selected = true;
+      }
+      opts.appendChild(opt);
+    }
+    this.select.appendChild(opts);
+    this.select.addEventListener('change', () => {
+      this.localizationManager.setLocale(this.select.value);
+    });
+
+    this.localizationManager.initialize();
+  }
+
+  updateConfig(config) {
+    // eslint-disable-next-line no-param-reassign
+    config.locale = this.localizationManager.getLocale();
+  }
+
+  applyConfig(config) {
+    if (config.locale) {
+      this.localizationManager.setLocale(config.locale);
+      const opt = this.select.querySelector(`[value="${config.locale}"]`);
+      opt.selected = true;
+    }
   }
 }

--- a/js/ui/locales/de_DE.json
+++ b/js/ui/locales/de_DE.json
@@ -1,0 +1,18 @@
+{
+  "_metadata_": {
+    "id": "de_DE",
+    "name": "Deutsch",
+    "flag": "de.svg"
+  },
+  "menu": {
+    "general_settings": {
+      "heading": "Allgemeine Einstellungen"
+    },
+    "locale_switch": {
+      "desc": "Sprache:"
+    },
+    "bg_color_control": {
+      "desc": "Hintergrundfarbe:"
+    }
+  }
+}

--- a/js/ui/locales/de_DE.json
+++ b/js/ui/locales/de_DE.json
@@ -83,6 +83,9 @@
     }
   },
   "menu": {
+    "apply_btn": {
+      "label": "Anwenden"
+    },
     "general_settings": {
       "heading": "Allgemeine Einstellungen"
     },
@@ -123,6 +126,9 @@
         "prompt": "Beispielkonfiguration laden"
       }
     },
+    "toggle_btn": {
+      "title": "Menü ein-/ausblenden"
+    },
     "bg_color_control": {
       "desc": "Hintergrundfarbe:"
     },
@@ -137,6 +143,9 @@
     "title": "Partikelspielplatz",
     "dropzone": {
       "desc": "Bilddatei ablegen zum Laden"
+    },
+    "upload_btn": {
+      "title": "Bild auswählen"
     }
   }
 }

--- a/js/ui/locales/de_DE.json
+++ b/js/ui/locales/de_DE.json
@@ -4,6 +4,84 @@
     "name": "Deutsch",
     "flag": "de.svg"
   },
+  "effects": {
+    "change_image": {
+      "display_name": "Wechsle Bild",
+      "description": "Ändert die Partikeldaten auf den Inhalt eines wählbaren Bildes (Datei oder URL)"
+    },
+    "converge_circle": {
+      "display_name": "Konvergiere auf Farbkreis",
+      "description": "Partikel werden zu ihrer Position auf einem um den Bildschirmmittelpunkt zentrierten Farbkreis gezogen"
+    },
+    "converge_point": {
+      "display_name": "Konvergiere zu Punkt",
+      "description": "Partikel werden zum Mittelpunkt des Bildschirms gezogen"
+    },
+    "dummy": {
+      "display_name": "Dummy",
+      "description": "Ein Effekt ohne Auswirkung - nützlich um die Timeline zu strecken, ohne dass etwas passiert"
+    },
+    "flickr_image": {
+      "display_name": "Flickr Bild",
+      "description": "Ändert die Partikeldaten auf den Inhalt eines Bildes aus dem Neue-Bilder-Feed von Flickr"
+    },
+    "hue_displace": {
+      "display_name": "Versatz nach Farbe",
+      "description": "Partikel werden in verschiedene Richtungen verschoben, in Abhängigkeit von ihrem Farbwert (Hue)"
+    },
+    "particle_displace": {
+      "display_name": "Partikelversatz",
+      "description": "Verschiebt alle Partikel in eine wählbare Richtung um die gleiche Distanz"
+    },
+    "particle_size_by_hue": {
+      "display_name": "Partikelgröße nach Farbe",
+      "description": "Abhängig von ihrer Farbe wird die größe der einzelnen Partikel variiert"
+    },
+    "particle_spacing": {
+      "display_name": "Partikelabstand",
+      "description": "Der Abstand zwischen Partikeln wird vergrößert oder verkleinert"
+    },
+    "particles_reduce": {
+      "display_name": "Partikelanzahl reduzieren",
+      "description": "Entfernt Partikel um einen wählbaren Faktor"
+    },
+    "reset_default_image": {
+      "display_name": "Standardbild zurücksetzen",
+      "description": "Setzt das aktive Bild auf das aktuelle Standardbild zurück (d.h. auf das Bild des Servers oder das vom Nutzer zuletzt gesetzte Bild)"
+    },
+    "smear": {
+      "display_name": "Verschmieren",
+      "description": "Smears the image in a circular way"
+    },
+    "smooth_trails": {
+      "display_name": "Weiche Bewegungsunschärfe",
+      "description": "Aktiviert einen etwas weicheren Nachleucht-Effekt"
+    },
+    "sparkle": {
+      "display_name": "Glitzern",
+      "description": "Partikelgröße und -helligkeit variieren zufällig"
+    },
+    "standing_wave": {
+      "display_name": "Stehende Welle",
+      "description": "Eine stehende Welle oszilliert"
+    },
+    "trails": {
+      "display_name": "Bewegungsunschärfe",
+      "description": "Aktiviert einen Nachleucht-Effekt, der Bewegungsunschärfe ähnelt"
+    },
+    "vignette": {
+      "display_name": "Vignette",
+      "description": "Senkt die Helligkeit an den Ecken um einen Röhrenfernseher-ähnlichen Eindruck zu erzielen"
+    },
+    "wave": {
+      "display_name": "Welle",
+      "description": "Eine Welle passiert den Bildschirm von links nach rechts"
+    },
+    "webcam": {
+      "display_name": "Webcam",
+      "description": "Nutzt die Webcam des Nutzers um die zugrundeliegenden Partikeldaten dynamisch zu verändern"
+    }
+  },
   "menu": {
     "general_settings": {
       "heading": "Allgemeine Einstellungen"

--- a/js/ui/locales/de_DE.json
+++ b/js/ui/locales/de_DE.json
@@ -11,8 +11,54 @@
     "locale_switch": {
       "desc": "Sprache:"
     },
+    "particles": {
+      "count": {
+        "desc": "Anzahl Partikel",
+        "horizontal": "Horizontal (x):",
+        "vertical": "Vertikal (y):"
+      },
+      "fading": {
+        "desc": "Partikelkante:",
+        "none": "hart",
+        "fade_out": "weich"
+      },
+      "overlap": {
+        "desc": "Partikelüberdeckung:",
+        "glow": "aufhellen",
+        "blend": "mischen"
+      },
+      "shape": {
+        "desc": "Partikelform:",
+        "circle": "Kreis",
+        "square": "Quadrat",
+        "triangle": "Dreieck"
+      },
+      "size": {
+        "desc": "Partikelgröße:"
+      }
+    },
+    "state": {
+      "load": "Laden",
+      "save": "Speichern",
+      "reset": "Zurücksetzen",
+      "load_preset": {
+        "prompt": "Beispielkonfiguration laden"
+      }
+    },
     "bg_color_control": {
       "desc": "Hintergrundfarbe:"
+    },
+    "weblinks": {
+      "desc": "Weblinks:",
+      "manual": "Handbuch",
+      "source_code": "Source Code (Github, MIT License)",
+      "default_image": "Voreingestelltes Bild: Edgar Degas (Wikimedia Commons)"
+    }
+  },
+  "page": {
+    "title": "Partikelspielplatz",
+    "dropzone": {
+      "desc": "Bilddatei ablegen zum Laden"
     }
   }
 }

--- a/js/ui/locales/en_US.json
+++ b/js/ui/locales/en_US.json
@@ -11,8 +11,54 @@
     "locale_switch": {
       "desc": "Language:"
     },
+    "particles": {
+      "count": {
+        "desc": "Number of particles",
+        "horizontal": "Horizontal (x):",
+        "vertical": "Vertical (y):"
+      },
+      "fading": {
+        "desc": "Particle edge fading:",
+        "none": "none",
+        "fade_out": "fade out"
+      },
+      "overlap": {
+        "desc": "Particle overlap:",
+        "glow": "glow",
+        "blend": "blend"
+      },
+      "shape": {
+        "desc": "Particle shape:",
+        "circle": "circle",
+        "square": "square",
+        "triangle": "triangle"
+      },
+      "size": {
+        "desc": "Particle size:"
+      }
+    },
+    "state": {
+      "load": "Load",
+      "save": "Save",
+      "reset": "Reset",
+      "load_preset": {
+        "prompt": "Load a preset configuration"
+      }
+    },
     "bg_color_control": {
       "desc": "Background color:"
+    },
+    "weblinks": {
+      "desc": "Weblinks:",
+      "manual": "Manual",
+      "source_code": "Source Code (Github, MIT License)",
+      "default_image": "Default image by Edgar Degas (Wikimedia Commons)"
+    }
+  },
+  "page": {
+    "title": "Particles Playground",
+    "dropzone": {
+      "desc": "Drop image file to load"
     }
   }
 }

--- a/js/ui/locales/en_US.json
+++ b/js/ui/locales/en_US.json
@@ -4,6 +4,84 @@
     "name": "English (US)",
     "flag": "us.svg"
   },
+  "effects": {
+    "change_image": {
+      "display_name": "Change Image",
+      "description": "Changes the particle data to a configurable image (file or url)"
+    },
+    "converge_circle": {
+      "display_name": "Converge to circle",
+      "description": "Particles are attracted towards their position on an HSV color wheel centered around the center of the screen"
+    },
+    "converge_point": {
+      "display_name": "Converge to point",
+      "description": "Particles are attracted towards the center of the screen"
+    },
+    "dummy": {
+      "display_name": "Dummy",
+      "description": "An effect that has no effect - useful to extend the timeline length without having anything happen"
+    },
+    "flickr_image": {
+      "display_name": "Flickr Image",
+      "description": "Changes the underlying image to one loaded from Flickr's recent images feed"
+    },
+    "hue_displace": {
+      "display_name": "Displace by Hue",
+      "description": "Particles move into different directions depending on their hue"
+    },
+    "particle_displace": {
+      "display_name": "Displace Particles",
+      "description": "Displaces all particles into a certain direction by the same distance"
+    },
+    "particle_size_by_hue": {
+      "display_name": "Particle Size by Hue",
+      "description": "Particles will have different sizes depending on their color"
+    },
+    "particle_spacing": {
+      "display_name": "Particle Spacing",
+      "description": "Adds or removes space between particles"
+    },
+    "particles_reduce": {
+      "display_name": "Reduce Particles Count",
+      "description": "Drops the given amount of particles"
+    },
+    "reset_default_image": {
+      "display_name": "Reset Default Image",
+      "description": "This effect changes the currently active image back to the default image (i.e. what came from the server or was uploaded by the user)"
+    },
+    "smear": {
+      "display_name": "Smear",
+      "description": "Smears the image in a circular way"
+    },
+    "smooth_trails": {
+      "display_name": "Smooth Trails",
+      "description": "Enables an smoother fading image echo"
+    },
+    "sparkle": {
+      "display_name": "Sparkle",
+      "description": "Particle size and brightness increase randomly"
+    },
+    "standing_wave": {
+      "display_name": "Standing Wave",
+      "description": "A standing wave oscillates"
+    },
+    "trails": {
+      "display_name": "Trails",
+      "description": "Enables an fading image echo"
+    },
+    "vignette": {
+      "display_name": "Vignette",
+      "description": "Fade out the edges to make it look like an old CRT TV"
+    },
+    "wave": {
+      "display_name": "Wave",
+      "description": "A wave passes through the particles from left to right over the screen"
+    },
+    "webcam": {
+      "display_name": "Webcam",
+      "description": "Make use of the user's webcam as the particles' color values"
+    }
+  },
   "menu": {
     "general_settings": {
       "heading": "General"

--- a/js/ui/locales/en_US.json
+++ b/js/ui/locales/en_US.json
@@ -1,0 +1,18 @@
+{
+  "_metadata_": {
+    "id": "en_US",
+    "name": "English (US)",
+    "flag": "us.svg"
+  },
+  "menu": {
+    "general_settings": {
+      "heading": "General"
+    },
+    "locale_switch": {
+      "desc": "Language:"
+    },
+    "bg_color_control": {
+      "desc": "Background color:"
+    }
+  }
+}

--- a/js/ui/locales/en_US.json
+++ b/js/ui/locales/en_US.json
@@ -83,6 +83,9 @@
     }
   },
   "menu": {
+    "apply_btn": {
+      "label": "Apply"
+    },
     "general_settings": {
       "heading": "General"
     },
@@ -123,6 +126,9 @@
         "prompt": "Load a preset configuration"
       }
     },
+    "toggle_btn": {
+      "title": "Toggle menu"
+    },
     "bg_color_control": {
       "desc": "Background color:"
     },
@@ -137,6 +143,9 @@
     "title": "Particles Playground",
     "dropzone": {
       "desc": "Drop image file to load"
+    },
+    "upload_btn": {
+      "title": "Select image"
     }
   }
 }

--- a/js/ui/menu.js
+++ b/js/ui/menu.js
@@ -3,55 +3,11 @@ import Config from '../config';
 import Timeline from './timeline';
 import Control from './control';
 import PresetSelect from './menu-preset-select';
-import LocalizationManager from './i18n';
+import { LocalePicker } from './i18n';
 import { parseHtml } from './util';
 
 import EffectConfig from '../effects/effect-config';
 import { effectList as effects } from '../effects/index';
-
-class LocalePicker extends Control {
-  constructor(menu) {
-    this.menu = menu;
-    this.element = document.getElementById('menu-locale-control');
-    this.select = this.element.querySelector('select');
-
-    this.localizationManager = new LocalizationManager();
-
-    const locales = LocalizationManager.getAvailableLocales();
-    const localeKeys = Object.keys(locales);
-    const opts = document.createDocumentFragment();
-    for (let i = 0; i < localeKeys.length; i++) {
-      const key = localeKeys[i];
-      const locale = locales[key];
-      const opt = document.createElement('option');
-      opt.value = key;
-      opt.textContent = locale._metadata_.name;
-      if (this.localizationManager.getLocale() === key) {
-        opt.selected = true;
-      }
-      opts.appendChild(opt);
-    }
-    this.select.appendChild(opts);
-    this.select.addEventListener('change', () => {
-      this.localizationManager.setLocale(this.select.value);
-    });
-
-    this.localizationManager.initialize();
-  }
-
-  updateConfig(config) {
-    // eslint-disable-next-line no-param-reassign
-    config.locale = this.localizationManager.getLocale();
-  }
-
-  applyConfig(config) {
-    if (config.locale) {
-      this.localizationManager.setLocale(config.locale);
-      const opt = this.select.querySelector(`[value="${config.locale}"]`);
-      opt.selected = true;
-    }
-  }
-}
 
 /**
  *

--- a/js/ui/menu.js
+++ b/js/ui/menu.js
@@ -3,10 +3,55 @@ import Config from '../config';
 import Timeline from './timeline';
 import Control from './control';
 import PresetSelect from './menu-preset-select';
+import LocalizationManager from './i18n';
 import { parseHtml } from './util';
 
 import EffectConfig from '../effects/effect-config';
 import { effectList as effects } from '../effects/index';
+
+class LocalePicker extends Control {
+  constructor(menu) {
+    this.menu = menu;
+    this.element = document.getElementById('menu-locale-control');
+    this.select = this.element.querySelector('select');
+
+    this.localizationManager = new LocalizationManager();
+
+    const locales = LocalizationManager.getAvailableLocales();
+    const localeKeys = Object.keys(locales);
+    const opts = document.createDocumentFragment();
+    for (let i = 0; i < localeKeys.length; i++) {
+      const key = localeKeys[i];
+      const locale = locales[key];
+      const opt = document.createElement('option');
+      opt.value = key;
+      opt.textContent = locale._metadata_.name;
+      if (this.localizationManager.getLocale() === key) {
+        opt.selected = true;
+      }
+      opts.appendChild(opt);
+    }
+    this.select.appendChild(opts);
+    this.select.addEventListener('change', () => {
+      this.localizationManager.setLocale(this.select.value);
+    });
+
+    this.localizationManager.initialize();
+  }
+
+  updateConfig(config) {
+    // eslint-disable-next-line no-param-reassign
+    config.locale = this.localizationManager.getLocale();
+  }
+
+  applyConfig(config) {
+    if (config.locale) {
+      this.localizationManager.setLocale(config.locale);
+      const opt = this.select.querySelector(`[value="${config.locale}"]`);
+      opt.selected = true;
+    }
+  }
+}
 
 /**
  *
@@ -277,7 +322,7 @@ class ResetAppstateButton extends Control {
 }
 
 const ControlsList = [
-  BgColorPicker, ParticleCountControl, DefaultImageControl,
+  LocalePicker, BgColorPicker, ParticleCountControl, DefaultImageControl,
   ParticleSizeControl, ParticleShapeControl, ParticleEdgeFadeControl, ParticleOverlapControl,
   PresetSelect,
   ExportAppstateButton, ImportAppstateButton, ResetAppstateButton

--- a/js/ui/menu.js
+++ b/js/ui/menu.js
@@ -3,7 +3,7 @@ import Config from '../config';
 import Timeline from './timeline';
 import Control from './control';
 import PresetSelect from './menu-preset-select';
-import { LocalePicker } from './i18n';
+import LocalizationManager, { LocalePicker } from './i18n';
 import { parseHtml } from './util';
 
 import EffectConfig from '../effects/effect-config';
@@ -285,15 +285,19 @@ const ControlsList = [
 ];
 
 class EffectListItem {
-  constructor(effect, timeline) {
+  constructor(effect, menu) {
     this.effect = effect;
-    this.timeline = timeline;
+    this.timeline = menu.getTimeline();
+    const i18n = menu.getLocalizationManager();
     this.element = parseHtml(`
-      <li title="${effect.getDescription()}">${effect.getDisplayName()}</li>
+      <li></li>
     `);
+    i18n.manageDOMElement(this.element, `effects.${effect.getTranslationId()}.display_name`);
+    i18n.manageDOMNodeAttr(this.element, 'title', `effects.${effect.getTranslationId()}.description`);
     this.dragCopy = parseHtml(`
-      <div class="effect-list-item drag-drop-copy">${effect.getDisplayName()}</div>
+      <div class="effect-list-item drag-drop-copy"></div>
     `);
+    i18n.manageDOMElement(this.dragCopy, `effects.${effect.getTranslationId()}.display_name`);
     
     const dragCopy = this.dragCopy;
     const showDragCopy = (x, y) => {
@@ -375,6 +379,7 @@ class EffectListItem {
 export default class MainMenu {
   constructor(clock) {
     this.menu = document.getElementById('menu-container');
+    this.localizationManager = new LocalizationManager();
     this.clock = clock;
     this.controls = [];
     this.changeListeners = [];
@@ -415,7 +420,7 @@ export default class MainMenu {
 
     const effectListElms = document.createDocumentFragment();
     for (let i = 0; i < effects.length; i++) {
-      const elm = new EffectListItem(effects[i], this.timeline).getElement();
+      const elm = new EffectListItem(effects[i], this).getElement();
       effectListElms.appendChild(elm);
     }
     this.effectList.appendChild(effectListElms);
@@ -439,6 +444,13 @@ export default class MainMenu {
     this.timeline.loadTimeline(tracks);
 
     this.submittedConfig = this.readConfig();
+  }
+
+  getTimeline() {
+    return this.timeline;
+  }
+  getLocalizationManager() {
+    return this.localizationManager;
   }
 
   applyConfig(config) {

--- a/js/ui/timeline.js
+++ b/js/ui/timeline.js
@@ -22,7 +22,6 @@ class TimelineEntry {
       <li class="${this.effect.isEventOnly() ? 'event' : ''}">
         <div class="${beginHandleClass}"></div>
         <button type="button" class="${getColorClassnameForEffect(this.effect)}">
-          ${this.effect.getDisplayName()}
         </button>
         <div class="${endHandleClass}"></div>
       </li>
@@ -52,6 +51,8 @@ class TimelineEntry {
     });
 
     this.openConfigBtn = this.element.querySelector('button');
+    const i18n = timeline.menu.getLocalizationManager();
+    i18n.manageDOMElement(this.openConfigBtn, `effects.${effect.getTranslationId()}.display_name`);
     this.openConfigBtn.addEventListener('click', () => {
       if (this.clickPrevented) {
         this.clickPrevented = false;


### PR DESCRIPTION
This is an effort to implement #79, i.e. i18n functionality.

Roadmap:
* [x] Allow for static html elements to be dynamically translated
* [x] Allow localization of dynamically created content
* [x] Allow localization of static html elements' attributes
* [x] Allow localization of dynamically created elements' attributes
* [x] Make display names and descriptions of effects translatable
* [ ] Create translations for all static html text
* [ ] Create translations for all effects' config dialogs
* [ ] Persist the selected locale in the user's config (but without causing render pipeline rebuild)